### PR TITLE
Fix the typo from iteartor to iterator

### DIFF
--- a/src/algorithm/heap.ts
+++ b/src/algorithm/heap.ts
@@ -23,7 +23,7 @@ import { advance, distance } from "../iterator/global";
 /**
  * Make a heap.
  *
- * @param first Random access iteartor of the first position.
+ * @param first Random access iterator of the first position.
  * @param last Random access iterator of the last position.
  * @param comp A binary function predicates *x* element would be placed before *y*. When returns `true`, then *x* precedes *y*. Default is {@link less}.
  */
@@ -54,7 +54,7 @@ export function make_heap<
 /**
  * Push an element into heap.
  *
- * @param first Random access iteartor of the first position.
+ * @param first Random access iterator of the first position.
  * @param last Random access iterator of the last position.
  * @param comp A binary function predicates *x* element would be placed before *y*. When returns `true`, then *x* precedes *y*. Default is {@link less}.
  */
@@ -77,7 +77,7 @@ export function push_heap<
 /**
  * Pop an element from heap.
  *
- * @param first Random access iteartor of the first position.
+ * @param first Random access iterator of the first position.
  * @param last Random access iterator of the last position.
  * @param comp A binary function predicates *x* element would be placed before *y*. When returns `true`, then *x* precedes *y*. Default is {@link less}.
  */
@@ -106,7 +106,7 @@ export function pop_heap<
 /**
  * Test whether a range is heap.
  *
- * @param first Bi-directional iteartor of the first position.
+ * @param first Bi-directional iterator of the first position.
  * @param last Bi-directional iterator of the last position.
  * @param comp A binary function predicates *x* element would be placed before *y*. When returns `true`, then *x* precedes *y*. Default is {@link less}.
  *
@@ -131,7 +131,7 @@ export function is_heap<
 /**
  * Find the first element not in heap order.
  *
- * @param first Bi-directional iteartor of the first position.
+ * @param first Bi-directional iterator of the first position.
  * @param last Bi-directional iterator of the last position.
  * @param comp A binary function predicates *x* element would be placed before *y*. When returns `true`, then *x* precedes *y*. Default is {@link less}.
  *
@@ -164,7 +164,7 @@ export function is_heap_until<
 /**
  * Sort elements of a heap.
  *
- * @param first Random access iteartor of the first position.
+ * @param first Random access iterator of the first position.
  * @param last Random access iterator of the last position.
  * @param comp A binary function predicates *x* element would be placed before *y*. When returns `true`, then *x* precedes *y*. Default is {@link less}.
  */

--- a/src/algorithm/iterations.ts
+++ b/src/algorithm/iterations.ts
@@ -25,7 +25,7 @@ import { Pair } from "../utility/Pair";
 /**
  * Apply a function to elements in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param fn The function to apply.
  *
@@ -45,7 +45,7 @@ export function for_each<
 /**
  * Apply a function to elements in steps.
  *
- * @param first Input iteartor of the starting position.
+ * @param first Input iterator of the starting position.
  * @param n Steps to maximum advance.
  * @param fn The function to apply.
  *
@@ -70,7 +70,7 @@ export function for_each_n<
 /**
  * Test whether all elements meet a specific condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A function predicates the specific condition.
  *
@@ -94,7 +94,7 @@ export function all_of<
 /**
  * Test whether any element meets a specific condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A function predicates the specific condition.
  *
@@ -118,7 +118,7 @@ export function any_of<
 /**
  * Test whether any element doesn't meet a specific condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A function predicates the specific condition.
  *
@@ -139,7 +139,7 @@ export function none_of<
 /**
  * Test whether two ranges are equal.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param pred A binary function predicates two arguments are equal.
@@ -162,7 +162,7 @@ export function equal<
 /**
  * Test whether two ranges are equal.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param pred A binary function predicates two arguments are equal.
@@ -214,7 +214,7 @@ export function equal<
 /**
  * Compare lexicographically.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -253,7 +253,7 @@ export function lexicographical_compare<
 /**
  * Find a value in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param val The value to find.
  *
@@ -274,7 +274,7 @@ export function find<
 /**
  * Find a matched condition in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A function predicates the specific condition.
  *
@@ -298,7 +298,7 @@ export function find_if<
 /**
  * Find a mismatched condition in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A function predicates the specific condition.
  *
@@ -319,7 +319,7 @@ export function find_if_not<
 /**
  * Find the last sub range.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -343,7 +343,7 @@ export function find_end<
 /**
  * Find the last sub range.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -409,7 +409,7 @@ export function find_end<
 /**
  * Find the first sub range.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -433,7 +433,7 @@ export function find_first_of<
 /**
  * Find the first sub range.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -486,7 +486,7 @@ export function find_first_of<
 /**
  * Find the first adjacent element.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A binary function predicates two arguments are equal. Default is {@link equal_to}.
  *
@@ -517,7 +517,7 @@ export function adjacent_find<
 /**
  * Search sub range.
  *
- * @param first1 Forward iteartor of the first position of the 1st range.
+ * @param first1 Forward iterator of the first position of the 1st range.
  * @param last1 Forward iterator of the last position of the 1st range.
  * @param first2 Forward iterator of the first position of the 2nd range.
  * @param last2 Forward iterator of the last position of the 2nd range.
@@ -541,7 +541,7 @@ export function search<
 /**
  * Search sub range.
  *
- * @param first1 Forward iteartor of the first position of the 1st range.
+ * @param first1 Forward iterator of the first position of the 1st range.
  * @param last1 Forward iterator of the last position of the 1st range.
  * @param first2 Forward iterator of the first position of the 2nd range.
  * @param last2 Forward iterator of the last position of the 2nd range.
@@ -604,7 +604,7 @@ export function search<
 /**
  * Search specific and repeated elements.
  *
- * @param first Forward iteartor of the first position.
+ * @param first Forward iterator of the first position.
  * @param last Forward iterator of the last position.
  * @param count Count to be repeated.
  * @param val Value to search.
@@ -641,7 +641,7 @@ export function search_n<
 /**
  * Find the first mistmached position between two ranges.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  *
@@ -663,7 +663,7 @@ export function mismatch<
 /**
  * Find the first mistmached position between two ranges.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param pred A binary function predicates two arguments are equal.
@@ -716,7 +716,7 @@ export function mismatch<
 /**
  * Count matched value in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param val The value to count.
  *
@@ -737,7 +737,7 @@ export function count<
 /**
  * Count matched condition in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A function predicates the specific condition.
  *

--- a/src/algorithm/mathematics.ts
+++ b/src/algorithm/mathematics.ts
@@ -184,7 +184,7 @@ export function clamp<T>(v: T, lo: T, hi: T, comp: Comparator<T> = less): T {
 /**
  * Test whether two ranges are in permutation relationship.
  *
- * @param first1 Forward iteartor of the first position of the 1st range.
+ * @param first1 Forward iterator of the first position of the 1st range.
  * @param last1 Forward iterator of the last position of the 1st range.
  * @param first2 Forward iterator of the first position of the 2nd range.
  * @param pred A binary function predicates two arguments are equal. Default is {@link equal_to}.

--- a/src/algorithm/merge.ts
+++ b/src/algorithm/merge.ts
@@ -27,7 +27,7 @@ import { copy } from "./modifiers";
 /**
  * Merge two sorted ranges.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -103,7 +103,7 @@ export function inplace_merge<
 /**
  * Test whether two sorted ranges are in inclusion relationship.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -138,7 +138,7 @@ export function includes<
 /**
  * Combine two sorted ranges to union relationship.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -190,7 +190,7 @@ export function set_union<
 /**
  * Combine two sorted ranges to intersection relationship.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -233,7 +233,7 @@ export function set_intersection<
 /**
  * Combine two sorted ranges to difference relationship.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.
@@ -277,7 +277,7 @@ export function set_difference<
 /**
  * Combine two sorted ranges to symmetric difference relationship.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param last2 Input iterator of the last position of the 2nd range.

--- a/src/algorithm/modifiers.ts
+++ b/src/algorithm/modifiers.ts
@@ -55,7 +55,7 @@ type BinaryOperatorInferrer<
 /**
  * Copy elements in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  *
@@ -83,7 +83,7 @@ export function copy<
 /**
  * Copy *n* elements.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param n Number of elements to copy.
  * @param output Output iterator of the first position.
  *
@@ -109,7 +109,7 @@ export function copy_n<
 /**
  * Copy specific elements by a condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  * @param pred A function predicates the specific condition.
@@ -141,7 +141,7 @@ export function copy_if<
 /**
  * Copy elements reversely.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  *
@@ -173,7 +173,7 @@ export function copy_backward<
 /**
  * Fill range elements
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param val The value to fill.
  *
@@ -194,7 +194,7 @@ export function fill<
 /**
  * Fill *n* elements.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param n Number of elements to fill.
  * @param val The value to fill.
  *
@@ -219,7 +219,7 @@ export function fill_n<
 /**
  * Transform elements.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  * @param op Unary function determines the transform.
@@ -243,7 +243,7 @@ export function transform<
 /**
  * Transform elements.
  *
- * @param first1 Input iteartor of the first position of the 1st range.
+ * @param first1 Input iterator of the first position of the 1st range.
  * @param last1 Input iterator of the last position of the 1st range.
  * @param first2 Input iterator of the first position of the 2nd range.
  * @param output Output iterator of the first position.
@@ -329,7 +329,7 @@ function _Binary_transform<
 /**
  * Generate range elements.
  *
- * @param first Forward iteartor of the first position.
+ * @param first Forward iterator of the first position.
  * @param last Forward iterator of the last position.
  * @param gen The generator function.
  */
@@ -348,7 +348,7 @@ export function generate<
 /**
  * Generate *n* elements.
  *
- * @param first Forward iteartor of the first position.
+ * @param first Forward iterator of the first position.
  * @param n Number of elements to generate.
  * @param gen The generator function.
  *
@@ -376,7 +376,7 @@ export function generate_n<
 /**
  * Test whether elements are unique in sorted range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A binary function predicates two arguments are equal. Default is {@link equal_to}.
  *
@@ -404,7 +404,7 @@ export function is_unique<
 /**
  * Remove duplicated elements in sorted range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred A binary function predicates two arguments are equal. Default is {@link equal_to}.
  *
@@ -433,7 +433,7 @@ export function unique<
 /**
  * Copy elements in range without duplicates.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the last position.
  * @param pred A binary function predicates two arguments are equal. Default is {@link equal_to}.
@@ -469,7 +469,7 @@ export function unique_copy<
 /**
  * Remove specific value in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param val The specific value to remove.
  *
@@ -490,7 +490,7 @@ export function remove<
 /**
  * Remove elements in range by a condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred An unary function predicates remove.
  *
@@ -520,7 +520,7 @@ export function remove_if<
 /**
  * Copy range removing specific value.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the last position.
  * @param val The condition predicates remove.
@@ -546,7 +546,7 @@ export function remove_copy<
 /**
  * Copy range removing elements by a condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the last position.
  * @param pred An unary function predicates remove.
@@ -582,7 +582,7 @@ export function remove_copy_if<
 /**
  * Replace specific value in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param old_val Specific value to change
  * @param new_val Specific value to be changed.
@@ -603,7 +603,7 @@ export function replace<
 /**
  * Replace specific condition in range.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param pred An unary function predicates the change.
  * @param new_val Specific value to be changed.
@@ -625,7 +625,7 @@ export function replace_if<
 /**
  * Copy range replacing specific value.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  * @param old_val Specific value to change
@@ -659,7 +659,7 @@ export function replace_copy<
 /**
  * Copy range replacing specfic condition.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  * @param pred An unary function predicates the change.
@@ -711,7 +711,7 @@ export function iter_swap<
 /**
  * Swap values of two ranges.
  *
- * @param first1 Forward iteartor of the first position of the 1st range.
+ * @param first1 Forward iterator of the first position of the 1st range.
  * @param last1 Forward iterator of the last position of the 1st range.
  * @param first2 Forward iterator of the first position of the 2nd range.
  *
@@ -817,9 +817,9 @@ export function shift_right<
 /**
  * Rotate elements in range.
  *
- * @param first Input iteartor of the first position.
- * @param middle Input iteartor of the initial position of the right side.
- * @param last Input iteartor of the last position.
+ * @param first Input iterator of the first position.
+ * @param middle Input iterator of the initial position of the right side.
+ * @param last Input iterator of the last position.
  *
  * @return Input iterator of the final position in the left side; *middle*.
  */
@@ -844,9 +844,9 @@ export function rotate<
 /**
  * Copy rotated elements in range.
  *
- * @param first Input iteartor of the first position.
- * @param middle Input iteartor of the initial position of the right side.
- * @param last Input iteartor of the last position.
+ * @param first Input iterator of the first position.
+ * @param middle Input iterator of the initial position of the right side.
+ * @param last Input iterator of the last position.
  * @param output Output iterator of the last position.
  *
  * @return Output Iterator of the last position by advancing.
@@ -871,8 +871,8 @@ export function rotate_copy<
 /**
  * Shuffle elements in range.
  *
- * @param first Random access iteartor of the first position.
- * @param last Random access iteartor of the last position.
+ * @param first Random access iterator of the first position.
+ * @param last Random access iterator of the last position.
  */
 export function shuffle<
   RandomAccessIterator extends General<

--- a/src/algorithm/random.ts
+++ b/src/algorithm/random.ts
@@ -28,7 +28,7 @@ export function randint(x: number, y: number): number {
 /**
  * Pick sample elements up.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output Output iterator of the first position.
  * @param n Number of elements to pick up.

--- a/src/algorithm/sorting.ts
+++ b/src/algorithm/sorting.ts
@@ -127,7 +127,7 @@ export function partial_sort<
 /**
  * Copy elements in range with partial sort.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  * @param output_first Output iterator of the first position.
  * @param output_last Output iterator of the last position.

--- a/src/base/container/IContainer.ts
+++ b/src/base/container/IContainer.ts
@@ -50,7 +50,7 @@ export interface IContainer<
   /**
    * Range Assigner.
    *
-   * @param first Input iteartor of the first position.
+   * @param first Input iterator of the first position.
    * @param last Input iterator of the last position.
    */
   assign<

--- a/src/base/container/ILinearContainer.ts
+++ b/src/base/container/ILinearContainer.ts
@@ -126,7 +126,7 @@ export interface ILinearContainer<
    *
    * @param pos Position to insert.
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    * @return An iterator to the first of the newly inserted elements.
    */
   insert<InputIterator extends Readonly<IForwardIterator<T, InputIterator>>>(

--- a/src/base/container/MultiMap.ts
+++ b/src/base/container/MultiMap.ts
@@ -70,7 +70,7 @@ export abstract class MultiMap<
    * Insert range elements.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public insert<
     InputIterator extends Readonly<

--- a/src/base/container/MultiSet.ts
+++ b/src/base/container/MultiSet.ts
@@ -49,7 +49,7 @@ export abstract class MultiSet<
    * Insert range elements.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public insert<
     InputIterator extends Readonly<IForwardIterator<Key, InputIterator>>,

--- a/src/base/container/UniqueMap.ts
+++ b/src/base/container/UniqueMap.ts
@@ -123,7 +123,7 @@ export abstract class UniqueMap<
    * Insert range elements.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public insert<
     InputIterator extends Readonly<

--- a/src/base/container/UniqueSet.ts
+++ b/src/base/container/UniqueSet.ts
@@ -60,7 +60,7 @@ export abstract class UniqueSet<
    * Insert range elements.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public insert<
     InputIterator extends Readonly<IForwardIterator<Key, InputIterator>>,

--- a/src/container/ForwardList.ts
+++ b/src/container/ForwardList.ts
@@ -123,7 +123,7 @@ export class ForwardList<T>
   /**
    * Range Assigner.
    *
-   * @param first Input iteartor of the first position.
+   * @param first Input iterator of the first position.
    * @param last Input iterator of the last position.
    */
   public assign<
@@ -253,7 +253,7 @@ export class ForwardList<T>
    *
    * @param pos Position to insert after.
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    * @return An iterator to the last of the newly inserted elements.
    */
   public insert_after<

--- a/src/container/List.ts
+++ b/src/container/List.ts
@@ -64,7 +64,7 @@ export class List<T>
    * Range Constructor.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public constructor(
     first: Readonly<IForwardIterator<T>>,

--- a/src/container/Vector.ts
+++ b/src/container/Vector.ts
@@ -71,7 +71,7 @@ export class Vector<T>
    * Range Constructor.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public constructor(
     first: Readonly<IForwardIterator<T>>,

--- a/src/container/VectorBoolean.ts
+++ b/src/container/VectorBoolean.ts
@@ -88,7 +88,7 @@ export class VectorBoolean
    * Range Constructor.
    *
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    */
   public constructor(
     first: Readonly<IForwardIterator<boolean>>,

--- a/src/internal/container/linear/ILinearContainerBase.ts
+++ b/src/internal/container/linear/ILinearContainerBase.ts
@@ -89,7 +89,7 @@ export interface ILinearContainerBase<
    *
    * @param pos Position to insert.
    * @param first Input iterator of the first position.
-   * @param last Input iteartor of the last position.
+   * @param last Input iterator of the last position.
    * @return An iterator to the first of the newly inserted elements.
    */
   insert<InputIterator extends Readonly<IForwardIterator<T, InputIterator>>>(

--- a/src/internal/iterator/disposable/ForOfAdaptor.ts
+++ b/src/internal/iterator/disposable/ForOfAdaptor.ts
@@ -23,7 +23,7 @@ export class ForOfAdaptor<
   /**
    * Initializer Constructor.
    *
-   * @param first Input iteartor of the first position.
+   * @param first Input iterator of the first position.
    * @param last Input iterator of the last position.
    */
   public constructor(first: InputIterator, last: InputIterator) {

--- a/src/iterator/global.ts
+++ b/src/iterator/global.ts
@@ -46,7 +46,7 @@ export function size(source: Array<any> | ISize): number {
 /**
  * Get distance between two iterators.
  *
- * @param first Input iteartor of the first position.
+ * @param first Input iterator of the first position.
  * @param last Input iterator of the last position.
  *
  * @return The distance.

--- a/src/ranges/algorithm/modifiers.ts
+++ b/src/ranges/algorithm/modifiers.ts
@@ -511,7 +511,7 @@ export function shift_right<
  * Rotate elements in range.
  *
  * @param range An iterable ranged container.
- * @param middle Input iteartor of the initial position of the right side.
+ * @param middle Input iterator of the initial position of the right side.
  *
  * @return Input iterator of the final position in the left side; *middle*.
  */
@@ -526,7 +526,7 @@ export function rotate<Range extends Array<any> | IForwardContainer<any>>(
  * Copy rotated elements in range.
  *
  * @param range An iterable ranged container.
- * @param middle Input iteartor of the initial position of the right side.
+ * @param middle Input iterator of the initial position of the right side.
  * @param output Output iterator of the last position.
  *
  * @return Output Iterator of the last position by advancing.


### PR DESCRIPTION
## Description
- Fix the typo `iteartor` to `iterator`